### PR TITLE
Merge Bug fix for AFL standings data

### DIFF
--- a/sports-scores/src/api/afl.api.ts
+++ b/sports-scores/src/api/afl.api.ts
@@ -126,5 +126,5 @@ export async function fetchAFLStandings(
     return handleAPIErrors(standings);
   }
 
-  return standings.response;
+  return standings.response.filter((item) => item.games.played > 19); //TODO: Remove for 2025
 }


### PR DESCRIPTION
AFL standings data from the API was updated and now contains duplicated values. This bug fix ensures the latest data is shown.