### PR TITLE
Refactor sports services to utilize mapFixtureRound and improve match handling

### DIFF
--- a/sports-scores/package-lock.json
+++ b/sports-scores/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sports-scores",
       "version": "1.0.0",
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-icons": "^1.3.1",
@@ -97,6 +98,12 @@
       "bin": {
         "findup": "bin/findup.js"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
@@ -2799,12 +2806,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3084,10 +3092,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3117,9 +3126,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3618,9 +3627,10 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -7664,10 +7674,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8881,15 +8892,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9458,9 +9460,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9501,15 +9503,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -10137,11 +10130,12 @@
       }
     },
     "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10341,15 +10335,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/sports-scores/package.json
+++ b/sports-scores/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-icons": "^1.3.1",

--- a/sports-scores/src/app/page.tsx
+++ b/sports-scores/src/app/page.tsx
@@ -2,7 +2,6 @@
 
 import EventCardGrid from "@/components/event-calendar/EventCardGrid";
 import RegularSeasonsView from "@/components/event-calendar/RegularSeasonsView";
-import { upcomingAndCurrentEvents } from "@/lib/constants";
 import { getUpcomingEvents } from "@/services/event-calendar.service";
 import { clsx } from "clsx";
 import { useState } from "react";
@@ -12,7 +11,7 @@ type ViewMode = "major" | "regular";
 export default function Home() {
   const [viewMode, setViewMode] = useState<ViewMode>("major");
   const adjustedDate = new Date();
-  adjustedDate.setDate(adjustedDate.getDate() - 10);
+  adjustedDate.setDate(adjustedDate.getDate() - 5);
 
   const upcomingEvents = getUpcomingEvents(adjustedDate);
 

--- a/sports-scores/src/app/sports/american-football/today/page.tsx
+++ b/sports-scores/src/app/sports/american-football/today/page.tsx
@@ -1,12 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import NoData from "@/components/misc-ui/NoData";
-import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { americanFootballMatchesByDate } from "@/services/american-football.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await americanFootballMatchesByDate(new Date());
+  const curDate = await getClientDate();
+  const pageData = await americanFootballMatchesByDate(curDate);
 
   if (pageData === null) {
     return <NoData href={"https://www.google.com/search?q=nfl"} />;

--- a/sports-scores/src/app/sports/aussie-rules/today/page.tsx
+++ b/sports-scores/src/app/sports/aussie-rules/today/page.tsx
@@ -1,11 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { aussieRulesCurrentMatches } from "@/services/aussie-rules.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await aussieRulesCurrentMatches("TODAY");
+  const curDate = await getClientDate();
+  const pageData = await aussieRulesCurrentMatches(curDate);
 
   if (pageData === null) {
     return <Placeholder>NO DATA</Placeholder>;

--- a/sports-scores/src/app/sports/baseball/today/page.tsx
+++ b/sports-scores/src/app/sports/baseball/today/page.tsx
@@ -1,11 +1,12 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { baseballMatchesByDate } from "@/services/baseball.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const curDate = new Date();
+  const curDate = await getClientDate();
   const pageData = await baseballMatchesByDate(curDate);
 
   if (pageData === null) {

--- a/sports-scores/src/app/sports/basketball/today/page.tsx
+++ b/sports-scores/src/app/sports/basketball/today/page.tsx
@@ -1,11 +1,12 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { basketballMatchesByDate } from "@/services/basketball.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const curDate = new Date();
+  const curDate = await getClientDate();
   const pageData = await basketballMatchesByDate(curDate);
 
   if (pageData === null) {

--- a/sports-scores/src/app/sports/cricket/today/page.tsx
+++ b/sports-scores/src/app/sports/cricket/today/page.tsx
@@ -1,11 +1,12 @@
 import FixtureList from "@/components/all-sports/FixtureList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { cricketMatchesRecent } from "@/services/cricket.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const curDate = new Date();
+  const curDate = await getClientDate();
   const matches = await cricketMatchesRecent(curDate);
 
   if (matches === null) {

--- a/sports-scores/src/app/sports/football/today/page.tsx
+++ b/sports-scores/src/app/sports/football/today/page.tsx
@@ -1,11 +1,12 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { footballMatchesByDate } from "@/services/football.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const curDate = new Date();
+  const curDate = await getClientDate();
   const pageData = await footballMatchesByDate(curDate);
 
   if (pageData === null) {

--- a/sports-scores/src/app/sports/ice-hockey/today/page.tsx
+++ b/sports-scores/src/app/sports/ice-hockey/today/page.tsx
@@ -1,11 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { iceHockeyMatchesByDate } from "@/services/ice-hockey.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await iceHockeyMatchesByDate(new Date());
+  const curDate = await getClientDate();
+  const pageData = await iceHockeyMatchesByDate(curDate);
 
   if (pageData === null) {
     return <Placeholder>NO DATA</Placeholder>;

--- a/sports-scores/src/app/sports/netball/today/page.tsx
+++ b/sports-scores/src/app/sports/netball/today/page.tsx
@@ -1,11 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { netballMatchesByDate } from "@/services/netball.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await netballMatchesByDate(new Date());
+  const curDate = await getClientDate();
+  const pageData = await netballMatchesByDate(curDate);
 
   if (pageData === null) {
     return <Placeholder>NO DATA</Placeholder>;

--- a/sports-scores/src/app/sports/rugby-league/today/page.tsx
+++ b/sports-scores/src/app/sports/rugby-league/today/page.tsx
@@ -1,11 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { rugbyLeagueMatchesByDate } from "@/services/rugby-league.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await rugbyLeagueMatchesByDate(new Date());
+  const curDate = await getClientDate();
+  const pageData = await rugbyLeagueMatchesByDate(curDate);
 
   if (pageData === null) {
     return <Placeholder>NO DATA</Placeholder>;

--- a/sports-scores/src/app/sports/rugby-union/today/page.tsx
+++ b/sports-scores/src/app/sports/rugby-union/today/page.tsx
@@ -1,11 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
+import { getClientDate } from "@/lib/serverUtils";
 import { rugbyUnionMatchesByDate } from "@/services/rugby-union.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const pageData = await rugbyUnionMatchesByDate(new Date());
+  const curDate = await getClientDate();
+  const pageData = await rugbyUnionMatchesByDate(curDate);
 
   if (pageData === null) {
     return <Placeholder>NO DATA</Placeholder>;

--- a/sports-scores/src/app/sports/tennis/today/page.tsx
+++ b/sports-scores/src/app/sports/tennis/today/page.tsx
@@ -1,14 +1,13 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import Placeholder from "@/components/misc-ui/Placeholder";
-import { getClientTimezone } from "@/lib/serverUtils";
+import { getClientDate } from "@/lib/serverUtils";
 import { TennisMatchesByDate } from "@/services/tennis.service";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const curDate = new Date();
-  const timezone = await getClientTimezone();
-  const pageData = await TennisMatchesByDate(curDate, timezone);
+  const curDate = await getClientDate();
+  const pageData = await TennisMatchesByDate(curDate);
   // const pageData = await TESTTennisMatchesByDate(curDate);
 
   if (pageData === null) {

--- a/sports-scores/src/app/sports/today/page.tsx
+++ b/sports-scores/src/app/sports/today/page.tsx
@@ -1,6 +1,6 @@
 import FixtureRoundList from "@/components/all-sports/FixtureRoundList";
 import { GOLF_TOURS, MOTORSPORT_CATEGORIES } from "@/lib/constants";
-import { getClientDate, getClientTimezone } from "@/lib/serverUtils";
+import { getClientDate } from "@/lib/serverUtils";
 import { americanFootballMatchesByDate } from "@/services/american-football.service";
 import { aussieRulesCurrentMatches } from "@/services/aussie-rules.service";
 import { baseballMatchesByDate } from "@/services/baseball.service";
@@ -19,7 +19,6 @@ export const dynamic = "force-dynamic";
 
 export default async function Page() {
   const curDate = await getClientDate();
-  const timezone = await getClientTimezone();
   const [
     cricketoday,
     tennisToday,
@@ -38,13 +37,13 @@ export default async function Page() {
     cyclingToday,
   ] = await Promise.all([
     cricketMatchesByDate(curDate),
-    tennisMatchesByDate(curDate, timezone),
+    tennisMatchesByDate(curDate),
     footballMatchesByDate(curDate),
     basketballMatchesByDate(curDate),
     baseballMatchesByDate(curDate),
     americanFootballMatchesByDate(curDate),
     rugbyLeagueMatchesByDate(curDate),
-    aussieRulesCurrentMatches("TODAY"),
+    aussieRulesCurrentMatches(curDate),
     golfTournamentsByDate(curDate),
     motorsportCategoriesByDate(curDate),
     rugbyUnionMatchesByDate(curDate),
@@ -58,7 +57,7 @@ export default async function Page() {
     .concat([
       {
         matches: cricketoday ?? [],
-        roundLabel: "🏏 Cricket",
+        roundLabel: "Cricket",
         roundSlug: `${SPORT.CRICKET}/main/matches`,
       },
     ])
@@ -68,14 +67,14 @@ export default async function Page() {
     .concat([
       {
         matches: golfToday ?? [],
-        roundLabel: "⛳ Golf",
+        roundLabel: "Golf",
         roundSlug: `${SPORT.GOLF}/${GOLF_TOURS[0].slug}/${GOLF_TOURS[0].seasons[0].slug}`,
       },
     ])
     .concat([
       {
         matches: motorsportToday ?? [],
-        roundLabel: "🏎️ Motorsport",
+        roundLabel: "Motorsport",
         roundSlug: `${SPORT.MOTORSPORT}/${MOTORSPORT_CATEGORIES[0].slug}/${MOTORSPORT_CATEGORIES[0].seasons[0].slug}`,
       },
     ])

--- a/sports-scores/src/components/misc-ui/ClientDateSetter.tsx
+++ b/sports-scores/src/components/misc-ui/ClientDateSetter.tsx
@@ -4,8 +4,6 @@ import { useEffect } from "react";
 
 export default function ClientDateSetter() {
   useEffect(() => {
-    const today = new Date().toISOString().split("T")[0]; // "2026-03-11"
-    document.cookie = `clientDate=${today}; path=/; max-age=86400`;
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     document.cookie = `clientTimezone=${encodeURIComponent(timezone)}; path=/; max-age=86400`;
   }, []);

--- a/sports-scores/src/lib/serverUtils.ts
+++ b/sports-scores/src/lib/serverUtils.ts
@@ -1,13 +1,13 @@
+import { TZDate } from "@date-fns/tz";
 import { cookies } from "next/headers";
-
-export async function getClientDate(): Promise<Date> {
-  const cookieStore = await cookies();
-  const clientDateStr = cookieStore.get("clientDate")?.value;
-  return clientDateStr ? new Date(clientDateStr) : new Date();
-}
 
 export async function getClientTimezone(): Promise<string> {
   const cookieStore = await cookies();
   const tz = cookieStore.get("clientTimezone")?.value;
   return tz ? decodeURIComponent(tz) : "UTC";
+}
+
+export async function getClientDate(): Promise<TZDate> {
+  const timezone = await getClientTimezone();
+  return new TZDate(new Date(), timezone);
 }

--- a/sports-scores/src/services/american-football.service.ts
+++ b/sports-scores/src/services/american-football.service.ts
@@ -20,7 +20,12 @@ import {
 } from "@/endpoints/sofascore.api";
 import { AMERICAN_FOOTBALL_LEAGUES, NFL_TEAM_NAMES } from "@/lib/constants";
 import { resolveSportImage } from "@/lib/imageMapping";
-import { setMatchSummary, shortenTeamNames } from "@/lib/projUtils";
+import {
+  getCurrentRound,
+  mapFixtureRound,
+  mapMatchSummary,
+  shortenTeamNames,
+} from "@/lib/projUtils";
 import {
   AmericanFootball_AmericanFootballApi_CategorySchedule_Response,
   AmericanFootball_Sofascore_Event,
@@ -28,7 +33,14 @@ import {
   AmericanFootballLadderPage,
   AmericanFootballMatchPage,
 } from "@/types/american-football";
-import { FixtureRound, MatchSummary, SPORT } from "@/types/misc";
+import {
+  API_EVENT_TYPES,
+  DISPLAY_TYPES,
+  MatchSummary,
+  SPORT,
+} from "@/types/misc";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function americanFootballMatches(league: number, season: number) {
   const lastMatches = await (
@@ -46,103 +58,25 @@ export async function americanFootballMatches(league: number, season: number) {
     nextMatches?.events ?? [],
   ) as AmericanFootball_Sofascore_Event[];
 
-  for (let i = 1; i < matches.length; i++) {
-    if (matches[i].roundInfo === undefined) {
-      matches[i].roundInfo = { round: 0 };
-    }
-  }
+  const displayType =
+    AMERICAN_FOOTBALL_LEAGUES.find((l) => Number(l.slug) === league)?.display ??
+    DISPLAY_TYPES.ROUND;
 
-  const rounds = [
-    ...new Set(
-      matches.map((item) => item.roundInfo?.name ?? item.roundInfo?.round),
-    ),
-  ];
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    displayType,
+    matches,
+    mapAmericanFootballMatch,
+    league === 9464,
+    NFL_TEAM_NAMES.map((team) => ({
+      name: team,
+      img: resolveSportImage(team),
+    })),
+  );
 
   return {
-    fixtures: rounds.map((round) => {
-      //Get all teams playing in the round
-      let teams = matches
-        .filter(
-          (item) =>
-            item.roundInfo?.round === round || item.roundInfo?.name === round,
-        )
-        .flatMap((game) => [game.homeTeam.name, game.awayTeam.name]);
-
-      return {
-        matches: matches
-          .filter(
-            (item) =>
-              item.roundInfo?.round === round || item.roundInfo?.name === round,
-          )
-
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel:
-                match.roundInfo?.name ?? `Week ${match.roundInfo?.round}`,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.AMERICAN_FOOTBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-                winDrawLoss: match.homeTeamSeasonHistoricalForm
-                  ? `${match.homeTeamSeasonHistoricalForm.wins ?? 0}-${match.homeTeamSeasonHistoricalForm.losses ?? 0}${match.homeTeamSeasonHistoricalForm.draws ? "-" + match.homeTeamSeasonHistoricalForm.draws : ""}`
-                  : null,
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-                winDrawLoss: match.awayTeamSeasonHistoricalForm
-                  ? `${match.awayTeamSeasonHistoricalForm.wins ?? 0}-${match.awayTeamSeasonHistoricalForm.losses ?? 0}${match.awayTeamSeasonHistoricalForm.draws ? "-" + match.awayTeamSeasonHistoricalForm.draws : ""}`
-                  : null,
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: typeof round === "string" ? round : `Week ${round}`,
-        byes:
-          typeof round !== "string"
-            ? NFL_TEAM_NAMES.filter((x) => !teams.includes(x)).map((team) => {
-                return {
-                  name: team,
-                  img: resolveSportImage(team),
-                };
-              })
-            : [],
-      } as FixtureRound;
-    }),
-
-    currentRound:
-      nextMatches !== null && nextMatches.events.length > 0
-        ? nextMatches?.events[0]?.roundInfo?.name !== undefined
-          ? nextMatches?.events[0]?.roundInfo?.name
-          : `Week ${
-              nextMatches?.events[0]?.roundInfo?.round ??
-              lastMatches?.events[lastMatches?.events.length - 1]?.roundInfo
-                ?.round ??
-              0
-            }`
-        : lastMatches?.events[lastMatches?.events.length - 1]?.roundInfo?.name,
+    fixtures: fixture,
+    currentRound: getCurrentRound(displayType, fixture),
   } as AmericanFootballFixturesPage;
 }
 
@@ -285,14 +219,14 @@ export async function americanFootballMatchesByDate(date: Date) {
   }
 
   const validLeagueIds = AMERICAN_FOOTBALL_LEAGUES.map((l) => Number(l.slug));
-  const leagueIdToName = Object.fromEntries(
-    AMERICAN_FOOTBALL_LEAGUES.map((l) => [
-      Number(l.slug),
-      { name: l.name, currentSeason: l.seasons[0].slug },
-    ]),
-  );
+
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )
@@ -302,68 +236,47 @@ export async function americanFootballMatchesByDate(date: Date) {
         validLeagueIds.indexOf(b.tournament.uniqueTournament.id),
     );
 
-  // Get unique league ids in order
-  const rounds = [
-    ...new Set(
-      matches.events.map((item) => item.tournament.uniqueTournament.id),
-    ),
-  ];
+  if (!matches.events || matches.events.length === 0) return null;
+
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    DISPLAY_TYPES.LEAGUE,
+    matches.events,
+    mapAmericanFootballMatch,
+    false,
+    undefined,
+    SPORT.AMERICAN_FOOTBALL,
+  );
 
   return {
-    fixtures: rounds.map((leagueId) => {
-      const roundLabel = leagueIdToName[leagueId]?.name ?? "";
-
-      return {
-        matches: matches.events
-          .filter((item) => item.tournament.uniqueTournament.id === leagueId)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: roundLabel,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.AMERICAN_FOOTBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-                winDrawLoss: match.homeTeamSeasonHistoricalForm
-                  ? `${match.homeTeamSeasonHistoricalForm?.wins ?? 0}-${match.homeTeamSeasonHistoricalForm?.losses ?? 0}${match.homeTeamSeasonHistoricalForm?.draws ? "-" + match.homeTeamSeasonHistoricalForm.draws : ""}`
-                  : null,
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-                winDrawLoss: match.awayTeamSeasonHistoricalForm
-                  ? `${match.awayTeamSeasonHistoricalForm?.wins ?? 0}-${match.awayTeamSeasonHistoricalForm?.losses ?? 0}${match.awayTeamSeasonHistoricalForm?.draws ? "-" + match.awayTeamSeasonHistoricalForm.draws : ""}`
-                  : null,
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: roundLabel,
-        roundSlug: `${SPORT.AMERICAN_FOOTBALL}/${leagueId}/${leagueIdToName[leagueId]?.currentSeason}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: leagueIdToName[rounds[0]]?.name ?? "NFL",
+    fixtures: fixture,
+    currentRound: getCurrentRound(DISPLAY_TYPES.LEAGUE, fixture),
   } as AmericanFootballFixturesPage;
+}
+
+function mapAmericanFootballMatch(
+  match: AmericanFootball_Sofascore_Event,
+  roundLabel: string,
+): MatchSummary {
+  let startDate = new Date(0);
+  startDate.setUTCSeconds(match.startTimestamp);
+
+  const summary = mapMatchSummary(
+    API_EVENT_TYPES.SOFASCORE,
+    SPORT.AMERICAN_FOOTBALL,
+    match,
+    {
+      startDate: startDate,
+      roundLabel: roundLabel,
+    },
+  );
+
+  summary.homeDetails.winDrawLoss = match.homeTeamSeasonHistoricalForm
+    ? `${match.homeTeamSeasonHistoricalForm.wins ?? 0}-${match.homeTeamSeasonHistoricalForm.losses ?? 0}${match.homeTeamSeasonHistoricalForm.draws ? "-" + match.homeTeamSeasonHistoricalForm.draws : ""}`
+    : undefined;
+  summary.awayDetails.winDrawLoss = match.awayTeamSeasonHistoricalForm
+    ? `${match.awayTeamSeasonHistoricalForm.wins ?? 0}-${match.awayTeamSeasonHistoricalForm.losses ?? 0}${match.awayTeamSeasonHistoricalForm.draws ? "-" + match.awayTeamSeasonHistoricalForm.draws : ""}`
+    : undefined;
+
+  return summary;
 }

--- a/sports-scores/src/services/aussie-rules.service.ts
+++ b/sports-scores/src/services/aussie-rules.service.ts
@@ -16,14 +16,28 @@ import {
 } from "@/endpoints/sofascore.api";
 import { AFL_TEAM_NAMES, AUSSIE_RULES_LEAGUES } from "@/lib/constants";
 import { resolveSportImage } from "@/lib/imageMapping";
-import { setMatchSummary, shortenTeamNames } from "@/lib/projUtils";
+import {
+  getCurrentRound,
+  mapFixtureRound,
+  mapMatchSummary,
+  shortenTeamNames,
+} from "@/lib/projUtils";
 import {
   AussieRulesFixturesPage,
   AussieRulesLadderPage,
   AussieRulesMatchPage,
   AussieRulesStanding,
+  AussieRulesTodayPage,
 } from "@/types/aussie-rules";
-import { FixtureRound, MatchSummary, SPORT } from "@/types/misc";
+import {
+  API_EVENT_TYPES,
+  DISPLAY_TYPES,
+  MatchSummary,
+  SPORT,
+} from "@/types/misc";
+import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function aussieRulesMatches(league: number, season: number) {
   const lastMatches = await (
@@ -39,73 +53,25 @@ export async function aussieRulesMatches(league: number, season: number) {
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
-  for (let i = 1; i < matches.length; i++) {
-    if (matches[i].roundInfo === undefined) {
-      matches[i].roundInfo = { round: 0 };
-    }
-  }
+  const displayType =
+    AUSSIE_RULES_LEAGUES.find((l) => Number(l.slug) === league)?.display ??
+    DISPLAY_TYPES.ROUND;
 
-  const rounds = [...new Set(matches.map((item) => item.roundInfo?.round))];
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    displayType,
+    matches,
+    mapAussieRulesMatch,
+    league === 656,
+    AFL_TEAM_NAMES.map((team) => ({
+      name: team,
+      img: resolveSportImage(team),
+    })),
+  );
 
   return {
-    fixtures: rounds.map((round) => {
-      //Get all teams playing in the round
-      let teams = matches
-        .filter((item) => item.roundInfo?.round === round)
-        .flatMap((game) => [game.homeTeam.name, game.awayTeam.name]);
-
-      return {
-        matches: matches
-          .filter((item) => item.roundInfo?.round === round)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: `Round ${match.roundInfo?.round}`,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.AUSSIE_RULES,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: `Round ${round}`,
-        byes: AFL_TEAM_NAMES.filter((x) => !teams.includes(x)).map((team) => {
-          return { name: team, img: resolveSportImage(team) };
-        }),
-      } as FixtureRound;
-    }),
-
-    currentRound: `Round ${
-      nextMatches?.events?.[0]?.roundInfo?.round ??
-      lastMatches?.events?.[lastMatches?.events.length - 1]?.roundInfo?.round ??
-      0
-    }`,
+    fixtures: fixture,
+    currentRound: getCurrentRound(displayType, fixture),
   } as AussieRulesFixturesPage;
 }
 
@@ -208,11 +174,9 @@ export async function aussieRulesMatchDetails(matchId: number) {
   } as AussieRulesMatchPage;
 }
 
-export async function aussieRulesCurrentMatches(
-  date: "TODAY" | "YESTERDAY" | "TOMORROW",
-) {
+export async function aussieRulesCurrentMatches(date: Date) {
   const matches = await (process.env.DEV_MODE
-    ? fetchEventsByDate("aussie-rules", new Date())
+    ? fetchEventsByDate("aussie-rules", date)
     : fetchScheduledEvents(87));
 
   if (!matches) {
@@ -220,14 +184,14 @@ export async function aussieRulesCurrentMatches(
   }
 
   const validLeagueIds = AUSSIE_RULES_LEAGUES.map((l) => Number(l.slug));
-  const leagueIdToName = Object.fromEntries(
-    AUSSIE_RULES_LEAGUES.map((l) => [
-      Number(l.slug),
-      { name: l.name, currentSeason: l.seasons[0].slug },
-    ]),
-  );
+
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )
@@ -237,62 +201,33 @@ export async function aussieRulesCurrentMatches(
         validLeagueIds.indexOf(b.tournament.uniqueTournament.id),
     );
 
-  // Get unique league ids in order
-  const rounds = [
-    ...new Set(
-      matches.events.map((item) => item.tournament.uniqueTournament.id),
-    ),
-  ];
+  if (!matches.events || matches.events.length === 0) return null;
+
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    DISPLAY_TYPES.LEAGUE,
+    matches.events,
+    mapAussieRulesMatch,
+    false,
+    undefined,
+    SPORT.AUSSIE_RULES,
+  );
 
   return {
-    fixtures: rounds.map((leagueId) => {
-      const roundLabel = leagueIdToName[leagueId]?.name ?? "";
+    fixtures: fixture,
+    currentRound: getCurrentRound(DISPLAY_TYPES.LEAGUE, fixture),
+  } as AussieRulesTodayPage;
+}
 
-      return {
-        matches: matches.events
-          .filter((item) => item.tournament.uniqueTournament.id === leagueId)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
+function mapAussieRulesMatch(
+  match: Sofascore_Event,
+  roundLabel: string,
+): MatchSummary {
+  let startDate = new Date(0);
+  startDate.setUTCSeconds(match.startTimestamp);
 
-            return {
-              startDate: startDate,
-              roundLabel: roundLabel,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.AUSSIE_RULES,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: roundLabel,
-        roundSlug: `${SPORT.AUSSIE_RULES}/${leagueId}/${leagueIdToName[leagueId]?.currentSeason}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: "AFL",
-  } as AussieRulesFixturesPage;
+  return mapMatchSummary(API_EVENT_TYPES.SOFASCORE, SPORT.AUSSIE_RULES, match, {
+    startDate: startDate,
+    roundLabel: roundLabel,
+  });
 }

--- a/sports-scores/src/services/baseball.service.ts
+++ b/sports-scores/src/services/baseball.service.ts
@@ -19,14 +19,27 @@ import {
 } from "@/endpoints/sofascore.api";
 import { BASEBALL_LEAGUES } from "@/lib/constants";
 import { resolveSportImage } from "@/lib/imageMapping";
-import { setMatchSummary, shortenTeamNames } from "@/lib/projUtils";
+import {
+  getCurrentRound,
+  mapFixtureRound,
+  mapMatchSummary,
+  shortenTeamNames,
+} from "@/lib/projUtils";
 import {
   BaseballFixturesPage,
   BaseballLadderPage,
   BaseballMatchPage,
   BaseballTodayPage,
 } from "@/types/baseball";
-import { FixtureRound, MatchSummary, SPORT } from "@/types/misc";
+import {
+  API_EVENT_TYPES,
+  DISPLAY_TYPES,
+  MatchSummary,
+  SPORT,
+} from "@/types/misc";
+import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function baseballMatches(tournamentId: number, seasonId: number) {
   const lastMatches = await (
@@ -43,70 +56,21 @@ export async function baseballMatches(tournamentId: number, seasonId: number) {
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
-  for (let i = 1; i < matches.length; i++) {
-    if (matches[i].roundInfo === undefined) {
-      matches[i].roundInfo = { round: 0 };
-    }
-  }
+  const displayType =
+    BASEBALL_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
+    DISPLAY_TYPES.ROUND;
 
-  const rounds = [...new Set(matches.map((item) => item.roundInfo?.round))];
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    displayType,
+    matches,
+    mapBaseballMatch,
+    false,
+  );
 
   return {
-    fixtures: rounds.map((round) => {
-      //Get all teams playing in the round
-      let teams = matches
-        .filter((item) => item.roundInfo?.round === round)
-        .flatMap((game) => [game.homeTeam.name, game.awayTeam.name]);
-
-      return {
-        matches: matches
-          .filter((item) => item.roundInfo?.round === round)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: `Round ${match.roundInfo?.round}`,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.BASEBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: `Round ${round}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: `Round ${
-      nextMatches?.events?.[0]?.roundInfo?.round ??
-      lastMatches?.events?.[lastMatches?.events.length - 1]?.roundInfo?.round ??
-      0
-    }`,
+    fixtures: fixture,
+    currentRound: getCurrentRound(displayType, fixture),
   } as BaseballFixturesPage;
 }
 
@@ -274,76 +238,34 @@ export async function baseballMatchesByDate(date: Date) {
   }
 
   const validLeagueIds = BASEBALL_LEAGUES.map((l) => Number(l.slug));
-  const leagueIdToName = Object.fromEntries(
-    BASEBALL_LEAGUES.map((l) => [
-      Number(l.slug),
-      { name: l.name, currentSeason: l.seasons[0].slug },
-    ]),
-  );
+
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )
     .sort((a, b) => a.startTimestamp - b.startTimestamp);
 
-  // Get unique league ids in order
-  const rounds = [
-    ...new Set(
-      matches.events.map((item) => item.tournament.uniqueTournament.id),
-    ),
-  ];
+  if (!matches.events || matches.events.length === 0) return null;
+
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    DISPLAY_TYPES.LEAGUE,
+    matches.events,
+    mapBaseballMatch,
+    false,
+    undefined,
+    SPORT.BASEBALL,
+  );
 
   return {
-    fixtures: rounds.map((leagueId) => {
-      const roundLabel = leagueIdToName[leagueId]?.name ?? "";
-      const seasonId = leagueIdToName[leagueId]?.currentSeason ?? "";
-      return {
-        matches: matches.events
-          .filter((item) => item.tournament.uniqueTournament.id === leagueId)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: roundLabel,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.BASEBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: roundLabel,
-        roundSlug: `${SPORT.BASEBALL}/${leagueId}/${seasonId}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: leagueIdToName[rounds[0]]?.name ?? "",
+    fixtures: fixture,
+    currentRound: getCurrentRound(DISPLAY_TYPES.LEAGUE, fixture),
   } as BaseballTodayPage;
 }
 
@@ -352,4 +274,17 @@ function tableOrder(name: string): number {
   if (name === "MLB") return 2;
   if (name.split(" ").length == 2) return 1;
   return 0; // Division tables
+}
+
+function mapBaseballMatch(
+  match: Sofascore_Event,
+  roundLabel: string,
+): MatchSummary {
+  let startDate = new Date(0);
+  startDate.setUTCSeconds(match.startTimestamp);
+
+  return mapMatchSummary(API_EVENT_TYPES.SOFASCORE, SPORT.BASEBALL, match, {
+    startDate: startDate,
+    roundLabel: roundLabel,
+  });
 }

--- a/sports-scores/src/services/basketball.service.ts
+++ b/sports-scores/src/services/basketball.service.ts
@@ -20,15 +20,27 @@ import {
 } from "@/endpoints/sofascore.api";
 import { BASKETBALL_LEAGUES } from "@/lib/constants";
 import { resolveSportImage } from "@/lib/imageMapping";
-import { setMatchSummary, shortenTeamNames } from "@/lib/projUtils";
+import {
+  getCurrentRound,
+  mapFixtureRound,
+  mapMatchSummary,
+  shortenTeamNames,
+} from "@/lib/projUtils";
 import {
   BasketballFixturesPage,
   BasketballLadderPage,
   BasketballMatchPage,
   BasketballTodayPage,
 } from "@/types/basketball";
-import { DISPLAY_TYPES, FixtureRound, MatchSummary, SPORT } from "@/types/misc";
-import { format } from "date-fns";
+import {
+  API_EVENT_TYPES,
+  DISPLAY_TYPES,
+  MatchSummary,
+  SPORT,
+} from "@/types/misc";
+import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function basketballMatches(
   tournamentId: number,
@@ -48,123 +60,21 @@ export async function basketballMatches(
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
-  for (let i = 1; i < matches.length; i++) {
-    if (matches[i].roundInfo === undefined) {
-      matches[i].roundInfo = { round: 0 };
-    }
-  }
-
   const displayType =
     BASKETBALL_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
-    "round";
+    DISPLAY_TYPES.ROUND;
 
-  function getMatchDate(match: any) {
-    let startDate = new Date(0);
-    startDate.setUTCSeconds(match.startTimestamp);
-    return format(startDate, "eee d MMM");
-  }
-
-  let rounds = [];
-  if (displayType === DISPLAY_TYPES.ROUND) {
-    rounds = [
-      ...new Set(
-        matches.map((item) => item.roundInfo?.name ?? item.roundInfo?.round),
-      ),
-    ].filter((round) => round !== undefined);
-  } else {
-    rounds = [
-      ...new Set(
-        matches
-          .sort((a, b) => a.startTimestamp - b.startTimestamp)
-          .map((item) => getMatchDate(item)),
-      ),
-    ];
-  }
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    displayType,
+    matches,
+    mapBasketballMatch,
+    false,
+  );
 
   return {
-    fixtures: rounds.map((round) => {
-      //Get all teams playing in the round
-      let teams = matches
-        .filter((item) =>
-          displayType === DISPLAY_TYPES.ROUND
-            ? item.roundInfo?.round === round || item.roundInfo?.name === round
-            : getMatchDate(item) === round,
-        )
-        .flatMap((game) => [game.homeTeam.name, game.awayTeam.name]);
-
-      return {
-        matches: matches
-          .filter((item) =>
-            displayType === DISPLAY_TYPES.ROUND
-              ? item.roundInfo?.round === round ||
-                item.roundInfo?.name === round
-              : getMatchDate(item) === round,
-          )
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel:
-                match.roundInfo?.name ?? `Round ${match.roundInfo?.round}`,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.BASKETBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: typeof round === "string" ? round : `Round ${round}`,
-        // byes: NRL_TEAM_NAMES.filter((x) => !teams.includes(x)).map((team) => {
-        //   return { name: team, img: resolveNRLImages(team) };
-        // }),
-      } as FixtureRound;
-    }),
-
-    currentRound: (() => {
-      if (displayType === DISPLAY_TYPES.ROUND) {
-        if (nextMatches !== null && nextMatches.events.length > 0) {
-          if (nextMatches?.events[0]?.roundInfo?.name !== undefined) {
-            return nextMatches?.events[0]?.roundInfo?.name;
-          } else {
-            const round = nextMatches?.events[0]?.roundInfo?.round ?? 0;
-            return `Round ${round}`;
-          }
-        } else {
-          return lastMatches?.events[lastMatches?.events.length - 1]?.roundInfo
-            ?.name;
-        }
-      } else {
-        let startDate = new Date();
-        return rounds.includes(format(startDate, "eee d MMM"))
-          ? format(startDate, "eee d MMM")
-          : rounds[0];
-      }
-    })(),
+    fixtures: fixture,
+    currentRound: getCurrentRound(displayType, fixture),
   } as BasketballFixturesPage;
 }
 
@@ -312,14 +222,14 @@ export async function basketballMatchesByDate(
   }
 
   const validLeagueIds = BASKETBALL_LEAGUES.map((l) => Number(l.slug));
-  const leagueIdToName = Object.fromEntries(
-    BASKETBALL_LEAGUES.map((l) => [
-      Number(l.slug),
-      { name: l.name, currentSeason: l.seasons[0].slug },
-    ]),
-  );
+
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )
@@ -329,62 +239,33 @@ export async function basketballMatchesByDate(
         validLeagueIds.indexOf(b.tournament.uniqueTournament.id),
     );
 
-  // Get unique league ids in order
-  const rounds = [
-    ...new Set(
-      matches.events.map((item) => item.tournament.uniqueTournament.id),
-    ),
-  ];
+  if (!matches.events || matches.events.length === 0) return null;
+
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    DISPLAY_TYPES.LEAGUE,
+    matches.events,
+    mapBasketballMatch,
+    false,
+    undefined,
+    SPORT.BASKETBALL,
+  );
 
   return {
-    fixtures: rounds.map((leagueId) => {
-      const roundLabel = leagueIdToName[leagueId]?.name ?? "";
-      const seasonId = leagueIdToName[leagueId]?.currentSeason ?? "";
-      return {
-        matches: matches.events
-          .filter((item) => item.tournament.uniqueTournament.id === leagueId)
-          .map((match) => {
-            var startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: roundLabel,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.BASKETBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: roundLabel,
-        roundSlug: `${SPORT.BASKETBALL}/${leagueId}/${seasonId}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: leagueIdToName[rounds[0]]?.name ?? "",
+    fixtures: fixture,
+    currentRound: getCurrentRound(DISPLAY_TYPES.LEAGUE, fixture),
   } as BasketballTodayPage;
+}
+
+function mapBasketballMatch(
+  match: Sofascore_Event,
+  roundLabel: string,
+): MatchSummary {
+  let startDate = new Date(0);
+  startDate.setUTCSeconds(match.startTimestamp);
+
+  return mapMatchSummary(API_EVENT_TYPES.SOFASCORE, SPORT.BASKETBALL, match, {
+    startDate: startDate,
+    roundLabel: roundLabel,
+  });
 }

--- a/sports-scores/src/services/football.service.ts
+++ b/sports-scores/src/services/football.service.ts
@@ -27,7 +27,13 @@ import {
 } from "@/endpoints/sofascore.api";
 import { FOOTBALL_LEAGUES } from "@/lib/constants";
 import { resolveSportImage } from "@/lib/imageMapping";
-import { setMatchSummary, shortenTeamNames } from "@/lib/projUtils";
+import {
+  getCurrentRound,
+  mapFixtureRound,
+  mapMatchSummary,
+  setMatchSummary,
+  shortenTeamNames,
+} from "@/lib/projUtils";
 import {
   FootballBracketPage,
   FootballFixturesPage,
@@ -36,7 +42,15 @@ import {
   FootballTeamFixturesPage,
   FootballTodayPage,
 } from "@/types/football";
-import { FixtureRound, MatchSummary, SPORT } from "@/types/misc";
+import {
+  API_EVENT_TYPES,
+  DISPLAY_TYPES,
+  MatchSummary,
+  SPORT,
+} from "@/types/misc";
+import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function footballMatches(tournamentId: number, seasonId: number) {
   const lastMatches = await (
@@ -53,90 +67,21 @@ export async function footballMatches(tournamentId: number, seasonId: number) {
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
-  for (let i = 1; i < matches.length; i++) {
-    if (matches[i].roundInfo === undefined) {
-      matches[i].roundInfo = { round: 0 };
-    }
-  }
+  const displayType =
+    FOOTBALL_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
+    DISPLAY_TYPES.ROUND;
 
-  const rounds = [
-    ...new Set(
-      matches.map((item) => item.roundInfo?.name ?? item.roundInfo?.round),
-    ),
-  ];
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    displayType,
+    matches,
+    mapFootballMatch,
+    false,
+  );
 
   return {
-    fixtures: rounds.map((round) => {
-      //Get all teams playing in the round
-      let teams = matches
-        .filter(
-          (item) => (item.roundInfo?.name ?? item.roundInfo?.round) === round,
-        )
-        .flatMap((game) => [game.homeTeam.name, game.awayTeam.name]);
-
-      return {
-        matches: matches
-          .filter(
-            (item) => (item.roundInfo?.name ?? item.roundInfo?.round) === round,
-          )
-          .map((match) => {
-            let startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel:
-                match.roundInfo?.name ?? `Round ${match.roundInfo?.round}`,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.FOOTBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: typeof round === "string" ? round : `Round ${round}`,
-        // byes: NRL_TEAM_NAMES.filter((x) => !teams.includes(x)).map((team) => {
-        //   return { name: team, img: resolveNRLImages(team) };
-        // }),
-      } as FixtureRound;
-    }),
-
-    currentRound: (() => {
-      if (nextMatches !== null && nextMatches.events.length > 0) {
-        if (nextMatches?.events[0]?.roundInfo?.name !== undefined) {
-          return nextMatches?.events[0]?.roundInfo?.name;
-        } else {
-          const round = nextMatches?.events[0]?.roundInfo?.round ?? 0;
-          return `Round ${round}`;
-        }
-      } else {
-        return lastMatches?.events[lastMatches?.events.length - 1]?.roundInfo
-          ?.name;
-      }
-    })(),
+    fixtures: fixture,
+    currentRound: getCurrentRound(displayType, fixture),
   } as FootballFixturesPage;
 }
 
@@ -311,14 +256,14 @@ export async function footballMatchesByDate(date: Date) {
   }
 
   const validLeagueIds = FOOTBALL_LEAGUES.map((l) => Number(l.slug));
-  const leagueIdToName = Object.fromEntries(
-    FOOTBALL_LEAGUES.map((l) => [
-      Number(l.slug),
-      { name: l.name, currentSeason: l.seasons[0].slug },
-    ]),
-  );
+
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )
@@ -328,63 +273,21 @@ export async function footballMatchesByDate(date: Date) {
         validLeagueIds.indexOf(b.tournament.uniqueTournament.id),
     );
 
-  // Get unique league ids in order
-  const rounds = [
-    ...new Set(
-      matches.events.map((item) => item.tournament.uniqueTournament.id),
-    ),
-  ];
+  if (!matches.events || matches.events.length === 0) return null;
+
+  const fixture = mapFixtureRound(
+    API_EVENT_TYPES.SOFASCORE,
+    DISPLAY_TYPES.LEAGUE,
+    matches.events,
+    mapFootballMatch,
+    false,
+    undefined,
+    SPORT.FOOTBALL,
+  );
 
   return {
-    fixtures: rounds.map((leagueId) => {
-      const roundLabel = leagueIdToName[leagueId]?.name ?? "";
-      const seasonId = leagueIdToName[leagueId]?.currentSeason ?? "";
-      return {
-        matches: matches.events
-          .filter((item) => item.tournament.uniqueTournament.id === leagueId)
-          .map((match) => {
-            let startDate = new Date(0);
-            startDate.setUTCSeconds(match.startTimestamp);
-
-            return {
-              startDate: startDate,
-              roundLabel: roundLabel,
-              timer:
-                match.status.type === "notstarted"
-                  ? startDate
-                  : match.status.description,
-              timerDisplayColour:
-                match.status.type === "inprogress" ? "green" : "gray",
-              id: match.id,
-              matchSlug: `${match.tournament.uniqueTournament.id}/${match.season.id}/${match.id}`,
-              sport: SPORT.FOOTBALL,
-              status: match.status.description,
-              venue: "",
-              summaryText: setMatchSummary(
-                match.status.type,
-                match.homeTeam.name,
-                match.homeScore.current,
-                match.awayTeam.name,
-                match.awayScore.current,
-              ),
-              homeDetails: {
-                name: shortenTeamNames(match.homeTeam.name),
-                score: match.homeScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.homeTeam.name),
-              },
-              awayDetails: {
-                name: shortenTeamNames(match.awayTeam.name),
-                score: match.awayScore.current?.toString() ?? "0",
-                img: resolveSportImage(match.awayTeam.name),
-              },
-            } as MatchSummary;
-          }),
-        roundLabel: roundLabel,
-        roundSlug: `${SPORT.FOOTBALL}/${leagueId}/${seasonId}`,
-      } as FixtureRound;
-    }),
-
-    currentRound: leagueIdToName[rounds[0]]?.name ?? "",
+    fixtures: fixture,
+    currentRound: getCurrentRound(DISPLAY_TYPES.LEAGUE, fixture),
   } as FootballTodayPage;
 }
 
@@ -465,4 +368,17 @@ export async function footballBrackets(tournamentId: number, seasonId: number) {
   return {
     brackets: tempBrackets,
   } as FootballBracketPage;
+}
+
+function mapFootballMatch(
+  match: Sofascore_Event,
+  roundLabel: string,
+): MatchSummary {
+  let startDate = new Date(0);
+  startDate.setUTCSeconds(match.startTimestamp);
+
+  return mapMatchSummary(API_EVENT_TYPES.SOFASCORE, SPORT.FOOTBALL, match, {
+    startDate: startDate,
+    roundLabel: roundLabel,
+  });
 }

--- a/sports-scores/src/services/ice-hockey.service.ts
+++ b/sports-scores/src/services/ice-hockey.service.ts
@@ -36,6 +36,8 @@ import {
   SPORT,
 } from "@/types/misc";
 import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function iceHockeyMatches(tournamentId: number, seasonId: number) {
   const lastMatches = await (
@@ -51,9 +53,13 @@ export async function iceHockeyMatches(tournamentId: number, seasonId: number) {
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
+  const displayType =
+    ICE_HOCKEY_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
+    DISPLAY_TYPES.ROUND;
+
   const fixture = mapFixtureRound(
     API_EVENT_TYPES.SOFASCORE,
-    DISPLAY_TYPES.ROUND,
+    displayType,
     matches,
     mapIceHockeyMatch,
     false,
@@ -61,7 +67,7 @@ export async function iceHockeyMatches(tournamentId: number, seasonId: number) {
 
   return {
     fixtures: fixture,
-    currentRound: getCurrentRound(DISPLAY_TYPES.ROUND, fixture),
+    currentRound: getCurrentRound(displayType, fixture),
   } as IceHockeyFixturesPage;
 }
 
@@ -177,8 +183,13 @@ export async function iceHockeyMatchesByDate(date: Date) {
   if (!matches) return null;
 
   const validLeagueIds = ICE_HOCKEY_LEAGUES.map((l) => Number(l.slug));
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )

--- a/sports-scores/src/services/netball.service.ts
+++ b/sports-scores/src/services/netball.service.ts
@@ -44,9 +44,13 @@ export async function netballMatches(tournamentId: number, seasonId: number) {
     new Map(allMatches.map((match) => [match.idEvent, match])).values(),
   );
 
+  const displayType =
+    NETBALL_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
+    DISPLAY_TYPES.ROUND;
+
   const fixture = mapFixtureRound(
     API_EVENT_TYPES.SPORTSDB,
-    DISPLAY_TYPES.ROUND,
+    displayType,
     matches,
     mapNetballMatch,
     false,
@@ -54,7 +58,7 @@ export async function netballMatches(tournamentId: number, seasonId: number) {
 
   return {
     fixtures: fixture,
-    currentRound: getCurrentRound(DISPLAY_TYPES.ROUND, fixture),
+    currentRound: getCurrentRound(displayType, fixture),
   } as NetballFixturesPage;
 }
 

--- a/sports-scores/src/services/rugby-league.service.ts
+++ b/sports-scores/src/services/rugby-league.service.ts
@@ -36,6 +36,8 @@ import {
   RugbyLeagueTodayPage,
 } from "@/types/rugby-league";
 import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function rugbyLeagueMatches(
   tournamentId: number,
@@ -54,9 +56,13 @@ export async function rugbyLeagueMatches(
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
+  const displayType =
+    RUGBY_LEAGUE_LEAGUES.find((l) => Number(l.slug) === tournamentId)
+      ?.display ?? DISPLAY_TYPES.ROUND;
+
   const fixture = mapFixtureRound(
     API_EVENT_TYPES.SOFASCORE,
-    DISPLAY_TYPES.ROUND,
+    displayType,
     matches,
     mapRugbyLeagueMatch,
     tournamentId === 294,
@@ -65,7 +71,7 @@ export async function rugbyLeagueMatches(
 
   return {
     fixtures: fixture,
-    currentRound: getCurrentRound(DISPLAY_TYPES.ROUND, fixture),
+    currentRound: getCurrentRound(displayType, fixture),
   } as RugbyLeagueFixturesPage;
 }
 
@@ -174,8 +180,13 @@ export async function rugbyLeagueMatchesByDate(date: Date) {
   if (!matches) return null;
 
   const validLeagueIds = RUGBY_LEAGUE_LEAGUES.map((l) => Number(l.slug));
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )

--- a/sports-scores/src/services/rugby-union.service.ts
+++ b/sports-scores/src/services/rugby-union.service.ts
@@ -39,6 +39,8 @@ import {
   RugbyUnionTodayPage,
 } from "@/types/rugby-union";
 import { Sofascore_Event } from "@/types/sofascore";
+import { TZDate } from "@date-fns/tz";
+import { isSameDay } from "date-fns";
 
 export async function rugbyUnionMatches(
   tournamentId: number,
@@ -57,9 +59,13 @@ export async function rugbyUnionMatches(
 
   const matches = (lastMatches?.events ?? []).concat(nextMatches?.events ?? []);
 
+  const displayType =
+    RUGBY_UNION_LEAGUES.find((l) => Number(l.slug) === tournamentId)?.display ??
+    DISPLAY_TYPES.ROUND;
+
   const fixture = mapFixtureRound(
     API_EVENT_TYPES.SOFASCORE,
-    DISPLAY_TYPES.ROUND,
+    displayType,
     matches,
     mapRugbyUnionMatch,
     tournamentId === 422,
@@ -68,7 +74,7 @@ export async function rugbyUnionMatches(
 
   return {
     fixtures: fixture,
-    currentRound: getCurrentRound(DISPLAY_TYPES.ROUND, fixture),
+    currentRound: getCurrentRound(displayType, fixture),
   } as RugbyUnionFixturesPage;
 }
 
@@ -179,8 +185,13 @@ export async function rugbyUnionMatchesByDate(date: Date) {
   if (!matches) return null;
 
   const validLeagueIds = RUGBY_UNION_LEAGUES.map((l) => Number(l.slug));
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
 
   matches.events = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
     .filter((item) =>
       validLeagueIds.includes(item.tournament.uniqueTournament.id),
     )

--- a/sports-scores/src/services/tennis.service.ts
+++ b/sports-scores/src/services/tennis.service.ts
@@ -32,6 +32,8 @@ import {
   TennisTeamFixturesPage,
   TennisTodayPage,
 } from "@/types/tennis";
+import { TZDate } from "@date-fns/tz";
+import { format, isSameDay } from "date-fns";
 
 export async function tennisTournamentMatches(
   tournamentId: number,
@@ -241,10 +243,8 @@ export async function TennisMatchDetails(matchId: number) {
   } as TennisMatchPage;
 }
 
-export async function TennisMatchesByDate(
-  date: Date,
-  timezone: string = "UTC",
-) {
+export async function TennisMatchesByDate(date: Date) {
+  const timezone = date instanceof TZDate ? date.timeZone : "UTC";
   const matches = await (process.env.DEV_MODE
     ? fetchEventsByDate("tennis", date)
     : fetchTennisMatchesByDate(date));
@@ -263,19 +263,29 @@ export async function TennisMatchesByDate(
     ]),
   );
 
-  const filteredMatches = matches.events.filter(
-    (item) =>
-      (validLeagueIds.includes(item.tournament.category.id) ||
-        validLeagueIds.includes(item.tournament.uniqueTournament.id)) &&
-      item.status.type !== "canceled",
-  );
+  const filteredMatches = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
+    .filter(
+      (item) =>
+        (validLeagueIds.includes(item.tournament.category.id) ||
+          validLeagueIds.includes(item.tournament.uniqueTournament.id)) &&
+        item.status.type !== "canceled",
+    );
 
-  const aussieMatches = matches.events.filter(
-    (item) =>
-      (item.homeTeam.country.name === "Australia" ||
-        item.awayTeam.country.name === "Australia") &&
-      item.status.type !== "canceled",
-  );
+  const aussieMatches = matches.events
+    .filter((item) => {
+      const eventDate = new TZDate(item.startTimestamp * 1000, timezone);
+      return isSameDay(eventDate, date);
+    })
+    .filter(
+      (item) =>
+        (item.homeTeam.country.name === "Australia" ||
+          item.awayTeam.country.name === "Australia") &&
+        item.status.type !== "canceled",
+    );
 
   // Get unique league ids in order
   const rounds = [
@@ -625,12 +635,7 @@ function sortMatchesByDateAndTournament(
 ): MatchSummary[] {
   // Group matches by date (in the user's timezone) and tournament
   const getLocalDateStr = (timestamp: number) =>
-    new Intl.DateTimeFormat("en-CA", {
-      timeZone: timezone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).format(new Date(timestamp * 1000));
+    format(new TZDate(timestamp * 1000, timezone), "yyyy-MM-dd");
 
   const groupKey = (match: Tennis_Sofascore_Event) =>
     `${getLocalDateStr(match.startTimestamp)}_${match.tournament.uniqueTournament.id}`;


### PR DESCRIPTION
- Updated Aussie Rules, Baseball, Basketball, Football, Ice Hockey, Netball, Rugby League, Rugby Union, and Tennis services to use mapFixtureRound for better fixture management.
- Introduced getCurrentRound function to streamline current round retrieval across services.
- Enhanced date filtering for matches using TZDate and isSameDay for accurate event matching.
- Removed redundant match processing logic and improved readability by consolidating match mapping into dedicated functions.